### PR TITLE
Enable the use of `__index` and `__newindex` metamethods

### DIFF
--- a/Class.lua
+++ b/Class.lua
@@ -1,5 +1,7 @@
 sm._class = sm._class or class
 local function emptyCtor() end
+local function defaultIndex(self, key) return self[key] end
+local function defaultNewindex(self, key, value) self[key] = value end
 
 --- Extends the current class function with a callable constructor.
 --- <br>The function is backwards compatible with the default implemenation.
@@ -16,10 +18,29 @@ function class(superType)
 
     function proxy:__call(...)
         newType.__init = newType.__init or emptyCtor
+
+        if not newType.__indexDefined then
+            newType.__get = type(newType.__index) == "function" and newType.__index or defaultIndex
+            newType.__set = newType.__newindex or defaultNewindex
+            newType.__index = newType
+            newType.__newindex = nil
+            newType.__indexDefined = true
+        end
+
         local instance = newType()
+        local pInstanceType = sm._class()
+
+        function pInstanceType:__index(key)
+            return newType.__get(instance, key)
+        end
+
+        function pInstanceType:__newindex(key, value)
+            newType.__set(instance, key, value)
+        end
+
         instance:__init(...)
 
-        return instance
+        return pInstanceType()
     end
 
     function proxy:__index(key)


### PR DESCRIPTION
Adds the ability to use `__index` and `__newindex` metamethods in classes.
Infinite recursion is avoided by first changing the original table keys `__index` and `__newindex` of the class to `__get` and `__set`, and using a proxy table that accesses the renamed metamethods on the actual class instance.
Instantiating a class now always returns a proxy object instead of the actual class instance.